### PR TITLE
add config to render mailchimp's automated response

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class SubscribeForm extends React.Component {
   }
   render() {
     const { action, messages, className, style, styles } = this.props
-    const { status } = this.state
+    const { status, msg } = this.state
     return (
       <div className={className} style={style}>
         <form action={action} method="post" noValidate>
@@ -71,8 +71,8 @@ class SubscribeForm extends React.Component {
             </button>
           </div>
           {status === "sending" && <p style={styles.sending} dangerouslySetInnerHTML={{ __html: messages.sending }} />}
-          {status === "success" && <p style={styles.success} dangerouslySetInnerHTML={{ __html: messages.success }} />}
-          {status === "error" && <p style={styles.error} dangerouslySetInnerHTML={{ __html: messages.error }} />}
+          {status === "success" && <p style={styles.success} dangerouslySetInnerHTML={{ __html: messages.success || msg }} />}
+          {status === "error" && <p style={styles.error} dangerouslySetInnerHTML={{ __html: messages.error || msg }} />}
         </form>
       </div>
     )


### PR DESCRIPTION
set `messages.success` or `messages.error` to `null` on the passed-in
props in order to render whatever markup mailchimp returns from signup
attempts.

So you can do something like this
```jsx
const FORM_PROPS = {
  action: "https://prizoners.us9.list-manage.com/subscribe/post?u=d66d8c5d1ef09114cf8c27ccb&id=3c7edc9b14",
  messages: {
    success: null,
    error: null 
  }
}

...
<SubscribeForm {...FORM_PROPS} />
...
```

And the form will display the Mailchimp response from signup attempts. This is handy for error messages like signing up for a newsletter a user might already be signed up for.